### PR TITLE
[feat: #5] TextField placeholder 추가

### DIFF
--- a/src/components/molecules/TextField.tsx
+++ b/src/components/molecules/TextField.tsx
@@ -8,6 +8,7 @@ interface TextFieldProps extends React.ComponentProps<'input'> {
   width?: string;
   label?: string;
   disabled?: boolean;
+  placeholder?: string;
   children?: string;
 }
 
@@ -23,11 +24,9 @@ const textFieldStyle = (palette: ColorPalette, label: boolean) => css`
     : css`
         padding: 0.75rem 0.625rem;
       `}
-  outline: none;
   box-sizing: border-box;
-  border-radius: 0.175rem;
   border: 0;
-  transition: all 100ms ease;
+  border-radius: 0.175rem;
 
   :enabled {
     border: 1px solid ${palette.border?.normal};
@@ -42,33 +41,45 @@ const textFieldStyle = (palette: ColorPalette, label: boolean) => css`
     background-color: ${palette.background?.disabled};
     color: ${palette.color?.disabled};
   }
+
+  transition: all 100ms ease;
+
+  outline: none;
 `;
 
 const normalLabel = (palette: ColorPalette, disabled: boolean) => css`
   position: absolute;
   top: 50%;
+
   margin-top: -0.5rem;
   margin-left: 0.625rem;
-  line-height: 1rem;
+
   color: ${disabled ? palette.color?.disabled : palette.color?.normal};
   font-size: 0.875rem;
-  pointer-events: none;
+  line-height: 1rem;
+
   transition: all 150ms ease;
+
+  pointer-events: none;
 `;
 
 const floatLabel = (palette: ColorPalette, focus: boolean, disabled: boolean) => css`
   position: absolute;
   top: 0.375rem;
+
   margin-left: 0.625rem;
-  line-height: 1rem;
-  color: ${disabled ? palette.color?.disabled : palette.color?.normal};
+
+  color: ${focus
+    ? palette.border?.focus
+    : disabled
+      ? palette.color?.disabled
+      : palette.color?.normal};
   font-size: 0.75rem;
-  pointer-events: none;
+  line-height: 1rem;
+
   transition: all 150ms ease;
-  ${focus &&
-  css`
-    color: ${palette.border?.focus};
-  `}
+
+  pointer-events: none;
 `;
 
 const TextField = ({
@@ -77,6 +88,7 @@ const TextField = ({
   width = '100%',
   label = '',
   disabled = false,
+  placeholder = '',
   children = '',
   onChange,
   onFocus,
@@ -122,6 +134,7 @@ const TextField = ({
           if (onBlur) onBlur(e);
         }}
         css={(theme) => textFieldStyle(theme.colors[variant].textfield, !!label)}
+        placeholder={label === '' ? placeholder : ''}
         disabled={disabled}
         {...props}
       />


### PR DESCRIPTION
<!-- 리뷰어랑 담당자, 라벨 설정했는지 확인하세요 -->

## 🥥 Contents

1. TextField label 값이 정의되지 않았으면 props에서 전달 받은 placeholder 를 표시하도록 변경
2. css 컨벤션에 맞게 스타일 수정

<!--
코드, 개발 관점에서 어떤걸 고쳤는지 상세하게
사진같은걸 넣어도 된다.
pr 보는 사람이 따로 정보를 안 찾아봐도 되게 적는게 이상적
-->

## ⚓ Related Issue
- #5 
<!-- 이슈 번호를 적어주면 되고, close 같은 자동 닫힘을 등록하여도 된다. -->

## 📚 Reference

<!-- 자신이 참조한 정보의 출처를 적는다. -->
